### PR TITLE
Add H2 DB support for streamlined dev processes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
             <version>42.7.3</version><!--added to fix error connecting to the DB-->
 			<scope>runtime</scope>
 		</dependency>
-        <!--adding 2 dependencies to use swaggers-->
+        <!--adding 2 dependencies to use swagger-->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
@@ -94,6 +94,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.3.232</version>
+        </dependency>
     </dependencies>
 
 	<build>

--- a/src/main/java/com/tuconnect/dorm_connect/mapper/UserMapper.java
+++ b/src/main/java/com/tuconnect/dorm_connect/mapper/UserMapper.java
@@ -16,7 +16,7 @@ public interface UserMapper {
     @Mapping(target = "password", source = "dto.password")
     @Mapping(target = "profileImageUrl", source = "dto.profileImageUrl")
     @Mapping(target = "major", source = "dto.major")
-    @Mapping(target = "year", source = "dto.year")
+    @Mapping(target = "academicYear", source = "dto.year")
     @Mapping(target = "role", source = "dto.role")
     User toEntity(UserDTO dto);
 

--- a/src/main/java/com/tuconnect/dorm_connect/model/User.java
+++ b/src/main/java/com/tuconnect/dorm_connect/model/User.java
@@ -3,7 +3,6 @@ package com.tuconnect.dorm_connect.model;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
@@ -38,7 +37,7 @@ public class User {
     private String major;
 
     @Column(nullable = false)
-    private Integer year;
+    private Integer academicYear;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "role")

--- a/src/main/java/com/tuconnect/dorm_connect/service/implementations/ChatServiceImpl.java
+++ b/src/main/java/com/tuconnect/dorm_connect/service/implementations/ChatServiceImpl.java
@@ -1,4 +1,4 @@
-package com.tuconnect.dorm_connect.service.ServiceImpl;
+package com.tuconnect.dorm_connect.service.implementations;
 
 import com.tuconnect.dorm_connect.dto.Chat.ChatDTO;
 import com.tuconnect.dorm_connect.dto.Messages.MessageDTO;

--- a/src/main/java/com/tuconnect/dorm_connect/service/implementations/DormServiceImpl.java
+++ b/src/main/java/com/tuconnect/dorm_connect/service/implementations/DormServiceImpl.java
@@ -1,4 +1,4 @@
-package com.tuconnect.dorm_connect.service.ServiceImpl;
+package com.tuconnect.dorm_connect.service.implementations;
 
 
 import com.tuconnect.dorm_connect.dto.Dorm.DormRequestDTO;

--- a/src/main/java/com/tuconnect/dorm_connect/service/implementations/EventServiceImpl.java
+++ b/src/main/java/com/tuconnect/dorm_connect/service/implementations/EventServiceImpl.java
@@ -1,4 +1,4 @@
-package com.tuconnect.dorm_connect.service.ServiceImpl;
+package com.tuconnect.dorm_connect.service.implementations;
 
 import com.tuconnect.dorm_connect.dto.Event.EventRequestDTO;
 import com.tuconnect.dorm_connect.dto.Event.EventResponseDTO;

--- a/src/main/java/com/tuconnect/dorm_connect/service/implementations/ListingServiceImpl.java
+++ b/src/main/java/com/tuconnect/dorm_connect/service/implementations/ListingServiceImpl.java
@@ -1,4 +1,4 @@
-package com.tuconnect.dorm_connect.service.ServiceImpl;
+package com.tuconnect.dorm_connect.service.implementations;
 
 import com.tuconnect.dorm_connect.dto.Listing.ListingRequestDTO;
 import com.tuconnect.dorm_connect.dto.Listing.ListingResponseDTO;

--- a/src/main/java/com/tuconnect/dorm_connect/service/implementations/MessageServiceImpl.java
+++ b/src/main/java/com/tuconnect/dorm_connect/service/implementations/MessageServiceImpl.java
@@ -1,4 +1,4 @@
-package com.tuconnect.dorm_connect.service.ServiceImpl;
+package com.tuconnect.dorm_connect.service.implementations;
 
 import com.tuconnect.dorm_connect.dto.Messages.MessageDTO;
 import com.tuconnect.dorm_connect.mapper.MessageMapper;

--- a/src/main/java/com/tuconnect/dorm_connect/service/implementations/ReviewServiceImpl.java
+++ b/src/main/java/com/tuconnect/dorm_connect/service/implementations/ReviewServiceImpl.java
@@ -1,4 +1,4 @@
-package com.tuconnect.dorm_connect.service.ServiceImpl;
+package com.tuconnect.dorm_connect.service.implementations;
 
 import com.tuconnect.dorm_connect.dto.Review.ReviewRequestDTO;
 import com.tuconnect.dorm_connect.dto.Review.ReviewResponseDTO;

--- a/src/main/java/com/tuconnect/dorm_connect/service/implementations/UserServiceImpl.java
+++ b/src/main/java/com/tuconnect/dorm_connect/service/implementations/UserServiceImpl.java
@@ -1,4 +1,4 @@
-package com.tuconnect.dorm_connect.service.ServiceImpl;
+package com.tuconnect.dorm_connect.service.implementations;
 
 import com.tuconnect.dorm_connect.dto.User.UserDTO;
 import com.tuconnect.dorm_connect.mapper.UserMapper;
@@ -42,7 +42,7 @@ public class UserServiceImpl implements UserService {
         user.setPassword(dto.password());
         user.setProfileImageUrl(dto.profileImageUrl());
         user.setMajor(dto.major());
-        user.setYear(dto.year());
+        user.setAcademicYear(dto.year());
         user.setRole(Roles.Users);
 
         User savedUser = userRepository.save(user);
@@ -61,7 +61,7 @@ public class UserServiceImpl implements UserService {
         existingUser.setPassword(updatedUserDTO.password());
         existingUser.setProfileImageUrl(updatedUserDTO.profileImageUrl());
         existingUser.setMajor(updatedUserDTO.major());
-        existingUser.setYear(updatedUserDTO.year());
+        existingUser.setAcademicYear(updatedUserDTO.year());
 
 
         User savedUser = userRepository.save(existingUser);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,13 +2,24 @@ spring.application.name=TU Connect
 spring.profiles.active=dev
 
 # PostgreSQL Database Configuration for application-dev.properties
+# UNCOMMENT THESE FOR DEMOS
 #spring.datasource.url=jdbc:postgresql://localhost:5432/<DataBase>
 #spring.datasource.username=<User>
 #spring.datasource.password=<Password>
+#spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+# H2 Database Configuration
+# ONLY INTENDED FOR USAGE DURING DEVELOPMENT PURPOSES, COMMENT OUT IF USING POSTGRESQL
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
 # Swagger
 springdoc.api-docs.path=/api-docs


### PR DESCRIPTION
- Refactored `year` field to `academicYear` across `User` model, `UserMapper`, and `UserServiceImpl` as it is a reserved keyword for h2 and other databases.
- Added H2 database dependency and updated development configuration for H2 support for streamlined development.
- Minor typo fix in POM comments.
- Change "ServiceImpls" package name to "implementations" as to fit package naming convention.